### PR TITLE
Add docker-compose.yml with a supporting redis instance for testing.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2'
+services:
+  nlp_hints:
+    image: teamforecast/nlp_hints:latest
+    depends_on:
+      - django_rq
+
+  django_rq:
+    image: redis:3.2.9


### PR DESCRIPTION
This new docker-compose.yml will start NLP-hints which will listen for Python-RQ jobs on the supporting Redis container configured with the expected 'django_rq' DNS name.

This is as a form of documentation and for testing.